### PR TITLE
Added timeout parameter

### DIFF
--- a/pycrtsh/api.py
+++ b/pycrtsh/api.py
@@ -24,12 +24,12 @@ class Crtsh(object):
     def __init__(self):
         pass
 
-    def search(self, query):
+    def search(self, query, timeout=None):
         """
         Search crt.sh with the give query
         Query can be domain, sha1, sha256...
         """
-        r = requests.get('https://crt.sh/', params={'q': query, 'output': 'json'})
+        r = requests.get('https://crt.sh/', params={'q': query, 'output': 'json'}, timeout=None)
         nameparser = re.compile("([a-zA-Z]+)=(\"[^\"]+\"|[^,]+)")
         certs = []
         try:

--- a/pycrtsh/api.py
+++ b/pycrtsh/api.py
@@ -29,7 +29,7 @@ class Crtsh(object):
         Search crt.sh with the give query
         Query can be domain, sha1, sha256...
         """
-        r = requests.get('https://crt.sh/', params={'q': query, 'output': 'json'}, timeout=None)
+        r = requests.get('https://crt.sh/', params={'q': query, 'output': 'json'}, timeout=timeout)
         nameparser = re.compile("([a-zA-Z]+)=(\"[^\"]+\"|[^,]+)")
         certs = []
         try:


### PR DESCRIPTION
crt.sh response time is quite slow which simply kills the efficiency of many tools based on it. Hence, a timeout parameter is added so that users can specify a time limit.